### PR TITLE
feat(stream): add Stream server & supervisor

### DIFF
--- a/lib/juicebox.ex
+++ b/lib/juicebox.ex
@@ -11,6 +11,7 @@ defmodule Juicebox do
       supervisor(Juicebox.Endpoint, []),
       # Start the Ecto repository
       worker(Juicebox.Repo, []),
+      worker(Juicebox.Stream.Supervisor, []),
       # Here you could define other workers and supervisors as children
       # worker(Juicebox.Worker, [arg1, arg2, arg3]),
     ]

--- a/lib/juicebox/stream/server.ex
+++ b/lib/juicebox/stream/server.ex
@@ -46,6 +46,13 @@ defmodule Juicebox.Stream.Server do
     GenServer.call(via_tuple(stream_id), :playing)
   end
 
+  @doc """
+  Returns a list of videos currently in the queue
+  """
+  def queue(stream_id) do
+    GenServer.call(via_tuple(stream_id), :get_queue)
+  end
+
   defp start(stream_id) do
     GenServer.call(via_tuple(stream_id), :start)
   end
@@ -77,6 +84,8 @@ defmodule Juicebox.Stream.Server do
     new_state = %{state | queue: new_queue}
     {:reply, {:ok, new_state}, new_state}
   end
+
+  def handle_call(:get_queue, _from, %{queue: queue} = state), do: {:reply, {:ok, queue}, state}
 
   def handle_info(:next, state) do
     {:noreply, play_next(state)}

--- a/lib/juicebox/stream/server.ex
+++ b/lib/juicebox/stream/server.ex
@@ -1,4 +1,8 @@
 defmodule Juicebox.Stream.Server do
+  @moduledoc """
+  Provides playlist-like behaviour for a queue of videos
+  """
+
   alias Juicebox.Youtube.Video
   use GenServer
 
@@ -10,10 +14,17 @@ defmodule Juicebox.Stream.Server do
     {:ok, %{playing: nil, timer: nil, queue: []}}
   end
 
+  @doc """
+  Skips the currently playing video. Playback will stop if the queue is empty.
+  """
   def skip(stream_id) do
     GenServer.call(via_tuple(stream_id), :skip)
   end
 
+  @doc """
+  Plays the video if one is not already playing, otherwise adds it to the
+  queue.
+  """
   def add(stream_id, video) do
     {:ok, state} = GenServer.call(via_tuple(stream_id), {:add, video})
 
@@ -21,10 +32,16 @@ defmodule Juicebox.Stream.Server do
     start(stream_id)
   end
 
+  @doc """
+  Returns (in ms) the playback time remaining for the current video
+  """
   def remaining_time(stream_id) do
     GenServer.call(via_tuple(stream_id), :remaining_time)
   end
 
+  @doc """
+  Returns the currently playing video (%Juicebox.Youtube.Video{})
+  """
   def playing(stream_id) do
     GenServer.call(via_tuple(stream_id), :playing)
   end

--- a/lib/juicebox/stream/supervisor.ex
+++ b/lib/juicebox/stream/supervisor.ex
@@ -1,0 +1,20 @@
+defmodule Juicebox.Stream.Supervisor do
+  use Supervisor
+
+  def start_link do
+    Supervisor.start_link(__MODULE__, [], name: :stream_supervisor)
+  end
+
+  def start_stream(stream_id) do
+    Supervisor.start_child(:stream_supervisor, [stream_id])
+  end
+
+  def init(_) do
+    children = [
+      worker(Juicebox.Stream.Server, [])
+    ]
+
+    supervise(children, strategy: :simple_one_for_one)
+  end
+end
+

--- a/lib/juicebox/stream/track.ex
+++ b/lib/juicebox/stream/track.ex
@@ -1,0 +1,5 @@
+defmodule Juicebox.Stream.Track do
+  defstruct video: %Juicebox.Youtube.Video{},
+            track_id: nil,
+            votes: 0
+end

--- a/lib/juicebox/youtube/client.ex
+++ b/lib/juicebox/youtube/client.ex
@@ -27,6 +27,7 @@ defmodule Juicebox.Youtube.Client do
       "snippet" => %{
         "title" => title,
         "description" => description,
+        "duration" => duration,
         "thumbnails" => %{
           "high" => %{
             "url" => thumbnail
@@ -39,6 +40,7 @@ defmodule Juicebox.Youtube.Client do
        video_id: video_id,
        title: title,
        description: description,
+       duration: duration,
        thumbnail: thumbnail
      }
   end

--- a/lib/juicebox/youtube/video.ex
+++ b/lib/juicebox/youtube/video.ex
@@ -2,5 +2,6 @@ defmodule Juicebox.Youtube.Video do
   defstruct video_id: nil,
             title: "",
             description: "",
-            thumbnail: ""
+            thumbnail: "",
+            duration: 8_000
 end

--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,7 @@ defmodule Juicebox.Mixfile do
   def application do
     [mod: {Juicebox, []},
      applications: [:phoenix, :phoenix_html, :cowboy, :logger,
-                    :phoenix_ecto, :postgrex, :httpoison,
+                    :phoenix_ecto, :postgrex, :httpoison, :gproc,
                     :phoenix_pubsub, :gettext]]
   end
 
@@ -43,8 +43,8 @@ defmodule Juicebox.Mixfile do
       {:hound, "~> 1.0", only: :test},
       {:junit_formatter, "~> 0.1", only: :test},
       {:httpoison, "~> 0.8.0"},
-      {:gproc, "~> 0.5.0"},
-      {:gettext, "~> 0.9"}
+      {:gettext, "~> 0.9"},
+      {:gproc, "~> 0.5.0"}
     ]
   end
 

--- a/test/juicebox/stream/server_test.exs
+++ b/test/juicebox/stream/server_test.exs
@@ -1,0 +1,116 @@
+defmodule Juicebox.Stream.ServerTests do
+  use ExUnit.Case, async: true
+  alias Juicebox.Stream.Server, as: Stream
+  alias Juicebox.Youtube.Video
+
+  @stream "test"
+
+  setup do
+    {:ok, server} = Stream.start_link(@stream)
+
+    [
+      video: %Video{title: "Video", duration: 100},
+      video_1: %Video{title: "Video 1", duration: 100},
+      video_2: %Video{title: "Video 2", duration: 100},
+      video_3: %Video{title: "Video 3", duration: 100},
+      server: server
+    ]
+  end
+
+  describe ".add" do
+    test "auto-starts playback", ctx do
+      {:ok, state} = Stream.add(@stream, ctx.video)
+      assert state.playing == ctx.video
+    end
+
+    test "adds to the queue if already playing", ctx do
+      {:ok, state} = Stream.add(@stream, ctx.video_1)
+      assert state.playing == ctx.video_1
+
+      {:ok, state} = Stream.add(@stream, ctx.video_2)
+      assert state.queue == [ctx.video_2]
+
+      {:ok, state} = Stream.add(@stream, ctx.video_3)
+      assert state.queue == [ctx.video_2, ctx.video_3]
+    end
+  end
+
+  describe ".playing" do
+    test "auto-starts playback", ctx do
+      Stream.add(@stream, ctx.video)
+
+      assert Stream.playing(@stream) == {:ok, ctx.video}
+    end
+  end
+
+
+
+  describe ".skip" do
+    test "skips to the next item in the queue", ctx do
+      Stream.add(@stream, ctx.video)
+      Stream.add(@stream, ctx.video_1)
+      Stream.add(@stream, ctx.video_2)
+      Stream.add(@stream, ctx.video_3)
+
+      {:ok, state} = Stream.skip(@stream)
+      assert state.playing == ctx.video_1
+
+      {:ok, state} = Stream.skip(@stream)
+      assert state.playing == ctx.video_2
+
+      {:ok, state} = Stream.skip(@stream)
+      assert state.playing == ctx.video_3
+
+      {:ok, state} = Stream.skip(@stream)
+      assert state.playing == nil
+    end
+  end
+
+  describe ".remaining_time" do
+    test "returns the time remaining for the current video", ctx do
+      Stream.add(@stream, ctx.video)
+
+      :timer.sleep(10)
+      {:ok, time} = Stream.remaining_time(@stream)
+      assert time <= 90
+
+      :timer.sleep(10)
+      {:ok, time} = Stream.remaining_time(@stream)
+      assert time <= 80
+    end
+  end
+
+  describe "auto-play" do
+    test "automatically plays videos until the queue is empty", ctx do
+      Stream.add(@stream, ctx.video)
+      Stream.add(@stream, ctx.video_1)
+      Stream.add(@stream, ctx.video_2)
+
+      assert Stream.playing(@stream) == {:ok, ctx.video}
+
+      :timer.sleep(105)
+      assert Stream.playing(@stream) == {:ok, ctx.video_1}
+
+      :timer.sleep(105)
+      assert Stream.playing(@stream) == {:ok, ctx.video_2}
+
+      :timer.sleep(105)
+      assert Stream.playing(@stream) == {:ok, nil}
+    end
+
+    test "automatically restarts playback when a video is added to the queue", ctx do
+      Stream.add(@stream, ctx.video)
+      assert Stream.playing(@stream) == {:ok, ctx.video}
+
+      :timer.sleep(105)
+      assert Stream.playing(@stream) == {:ok, nil}
+
+      Stream.add(@stream, ctx.video_1)
+      assert Stream.playing(@stream) == {:ok, ctx.video_1}
+
+      :timer.sleep(105)
+      assert Stream.playing(@stream) == {:ok, nil}
+    end
+  end
+
+end

--- a/test/juicebox/stream/server_test.exs
+++ b/test/juicebox/stream/server_test.exs
@@ -1,63 +1,71 @@
 defmodule Juicebox.Stream.ServerTests do
   use ExUnit.Case, async: true
   alias Juicebox.Stream.Server, as: Stream
+  alias Juicebox.Stream.Track
   alias Juicebox.Youtube.Video
 
   @stream "test"
+
+  defp create_track(track_id, attrs \\ %{}) do
+    %Track{
+      track_id: track_id,
+      video: Map.merge(%Video{title: "Video", duration: 100}, attrs)
+    }
+  end
 
   setup do
     {:ok, server} = Stream.start_link(@stream)
 
     [
-      video: %Video{title: "Video", duration: 100},
-      video_1: %Video{title: "Video 1", duration: 100},
-      video_2: %Video{title: "Video 2", duration: 100},
-      video_3: %Video{title: "Video 3", duration: 100},
+      track: create_track(0),
+      track_1: create_track(1, %{title: "Video 1", duration: 100}),
+      track_2: create_track(2, %{title: "Video 2", duration: 100}),
+      track_3: create_track(3, %{title: "Video 3", duration: 100}),
       server: server
     ]
   end
 
   describe ".add" do
     test "auto-starts playback", ctx do
-      {:ok, state} = Stream.add(@stream, ctx.video)
-      assert state.playing == ctx.video
+      {:ok, state} = Stream.add(@stream, ctx.track)
+      assert state.playing == ctx.track
     end
 
     test "adds to the queue if already playing", ctx do
-      {:ok, state} = Stream.add(@stream, ctx.video_1)
-      assert state.playing == ctx.video_1
+      {:ok, state} = Stream.add(@stream, ctx.track_1)
+      assert state.playing == ctx.track_1
 
-      {:ok, state} = Stream.add(@stream, ctx.video_2)
-      assert state.queue == [ctx.video_2]
+      {:ok, state} = Stream.add(@stream, ctx.track_2)
+      assert state.queue == [ctx.track_2]
 
-      {:ok, state} = Stream.add(@stream, ctx.video_3)
-      assert state.queue == [ctx.video_2, ctx.video_3]
+      {:ok, state} = Stream.add(@stream, ctx.track_3)
+      assert state.queue == [ctx.track_2, ctx.track_3]
     end
   end
 
   describe ".playing" do
     test "auto-starts playback", ctx do
-      Stream.add(@stream, ctx.video)
+      Stream.add(@stream, ctx.track)
 
-      assert Stream.playing(@stream) == {:ok, ctx.video}
+      assert Stream.playing(@stream) == {:ok, ctx.track}
     end
   end
 
   describe ".skip" do
     test "skips to the next item in the queue", ctx do
-      Stream.add(@stream, ctx.video)
-      Stream.add(@stream, ctx.video_1)
-      Stream.add(@stream, ctx.video_2)
-      Stream.add(@stream, ctx.video_3)
+      Stream.add(@stream, ctx.track)
+      Stream.add(@stream, ctx.track_1)
+      Stream.add(@stream, ctx.track_2)
+      Stream.add(@stream, ctx.track_3)
 
       {:ok, state} = Stream.skip(@stream)
-      assert state.playing == ctx.video_1
+      assert state.playing == ctx.track_1
 
       {:ok, state} = Stream.skip(@stream)
-      assert state.playing == ctx.video_2
+      assert state.playing == ctx.track_2
 
       {:ok, state} = Stream.skip(@stream)
-      assert state.playing == ctx.video_3
+      assert state.playing == ctx.track_3
 
       {:ok, state} = Stream.skip(@stream)
       assert state.playing == nil
@@ -65,8 +73,8 @@ defmodule Juicebox.Stream.ServerTests do
   end
 
   describe ".remaining_time" do
-    test "returns the time remaining for the current video", ctx do
-      Stream.add(@stream, ctx.video)
+    test "returns the time remaining for the current track", ctx do
+      Stream.add(@stream, ctx.track)
 
       :timer.sleep(10)
       {:ok, time} = Stream.remaining_time(@stream)
@@ -79,42 +87,110 @@ defmodule Juicebox.Stream.ServerTests do
   end
 
   describe ".queue" do
-    test "returns the videos in the queue", ctx do
-      Stream.add(@stream, ctx.video)
-      Stream.add(@stream, ctx.video_1)
-      Stream.add(@stream, ctx.video_2)
+    test "returns the tracks in the queue", ctx do
+      Stream.add(@stream, ctx.track)
+      Stream.add(@stream, ctx.track_1)
+      Stream.add(@stream, ctx.track_2)
 
-      assert Stream.queue(@stream) == {:ok, [ctx.video_1, ctx.video_2]}
+      assert Stream.queue(@stream) == {:ok, [ctx.track_1, ctx.track_2]}
+    end
+  end
+
+  describe ".vote" do
+    test "increments the vote count for a given track", ctx do
+      Stream.add(@stream, ctx.track)
+      Stream.add(@stream, ctx.track_1)
+      Stream.add(@stream, ctx.track_2)
+
+      {:ok, [track, _]} = Stream.queue(@stream)
+      assert track.votes == 0
+
+      Stream.vote(@stream, 1)
+      {:ok, [track, _]} = Stream.queue(@stream)
+      assert track.votes == 1
+
+      Stream.vote(@stream, 1)
+      {:ok, [track, _]} = Stream.queue(@stream)
+      assert track.votes == 2
+
+      # ensure we're only updating one track
+      {:ok, [_, track]} = Stream.queue(@stream)
+      assert track.votes == 0
+    end
+
+    test "sorts the queue by the number of votes", ctx do
+      Stream.add(@stream, ctx.track)
+      Stream.add(@stream, ctx.track_1)
+      Stream.add(@stream, ctx.track_2)
+
+      assert {:ok, [
+        %{ctx.track_1 | votes: 0},
+        %{ctx.track_2 | votes: 0}
+      ]} == Stream.queue(@stream)
+
+      Stream.vote(@stream, 2)
+      assert {:ok, [
+        %{ctx.track_2 | votes: 1},
+        %{ctx.track_1 | votes: 0}
+      ]} == Stream.queue(@stream)
+
+      Stream.vote(@stream, 1)
+      Stream.vote(@stream, 1)
+      assert {:ok, [
+        %{ctx.track_1 | votes: 2},
+        %{ctx.track_2 | votes: 1}
+      ]} == Stream.queue(@stream)
     end
   end
 
   describe "auto-play" do
-    test "automatically plays videos until the queue is empty", ctx do
-      Stream.add(@stream, ctx.video)
-      Stream.add(@stream, ctx.video_1)
-      Stream.add(@stream, ctx.video_2)
+    test "automatically plays tracks until the queue is empty", ctx do
+      Stream.add(@stream, ctx.track)
+      Stream.add(@stream, ctx.track_1)
+      Stream.add(@stream, ctx.track_2)
 
-      assert Stream.playing(@stream) == {:ok, ctx.video}
-
-      :timer.sleep(105)
-      assert Stream.playing(@stream) == {:ok, ctx.video_1}
+      assert Stream.playing(@stream) == {:ok, ctx.track}
 
       :timer.sleep(105)
-      assert Stream.playing(@stream) == {:ok, ctx.video_2}
+      assert Stream.playing(@stream) == {:ok, ctx.track_1}
+
+      :timer.sleep(105)
+      assert Stream.playing(@stream) == {:ok, ctx.track_2}
 
       :timer.sleep(105)
       assert Stream.playing(@stream) == {:ok, nil}
     end
 
-    test "automatically restarts playback when a video is added to the queue", ctx do
-      Stream.add(@stream, ctx.video)
-      assert Stream.playing(@stream) == {:ok, ctx.video}
+    test "automatically restarts playback when a track is added to the queue", ctx do
+      Stream.add(@stream, ctx.track)
+      assert Stream.playing(@stream) == {:ok, ctx.track}
 
       :timer.sleep(105)
       assert Stream.playing(@stream) == {:ok, nil}
 
-      Stream.add(@stream, ctx.video_1)
-      assert Stream.playing(@stream) == {:ok, ctx.video_1}
+      Stream.add(@stream, ctx.track_1)
+      assert Stream.playing(@stream) == {:ok, ctx.track_1}
+
+      :timer.sleep(105)
+      assert Stream.playing(@stream) == {:ok, nil}
+    end
+
+    test "respects the number of votes", ctx do
+      Stream.add(@stream, ctx.track)
+      Stream.add(@stream, ctx.track_1)
+      Stream.add(@stream, ctx.track_2)
+
+      assert Stream.playing(@stream) == {:ok, ctx.track}
+
+      Stream.vote(@stream, 2)
+      Stream.vote(@stream, 2)
+      Stream.vote(@stream, 1)
+
+      :timer.sleep(105)
+      assert Stream.playing(@stream) == {:ok, %{ctx.track_2 | votes: 2}}
+
+      :timer.sleep(105)
+      assert Stream.playing(@stream) == {:ok, %{ctx.track_1 | votes: 1}}
 
       :timer.sleep(105)
       assert Stream.playing(@stream) == {:ok, nil}

--- a/test/juicebox/stream/server_test.exs
+++ b/test/juicebox/stream/server_test.exs
@@ -43,8 +43,6 @@ defmodule Juicebox.Stream.ServerTests do
     end
   end
 
-
-
   describe ".skip" do
     test "skips to the next item in the queue", ctx do
       Stream.add(@stream, ctx.video)

--- a/test/juicebox/stream/server_test.exs
+++ b/test/juicebox/stream/server_test.exs
@@ -78,6 +78,16 @@ defmodule Juicebox.Stream.ServerTests do
     end
   end
 
+  describe ".queue" do
+    test "returns the videos in the queue", ctx do
+      Stream.add(@stream, ctx.video)
+      Stream.add(@stream, ctx.video_1)
+      Stream.add(@stream, ctx.video_2)
+
+      assert Stream.queue(@stream) == {:ok, [ctx.video_1, ctx.video_2]}
+    end
+  end
+
   describe "auto-play" do
     test "automatically plays videos until the queue is empty", ctx do
       Stream.add(@stream, ctx.video)

--- a/test/support/youtube/dummy_api.ex
+++ b/test/support/youtube/dummy_api.ex
@@ -13,6 +13,7 @@ defmodule Juicebox.Youtube.DummyAPI do
           "snippet" => %{
             "title" => "Dummy",
             "description" => "Video",
+            "duration" => 5000,
             "thumbnails" => %{
               "high" => %{
                 "url" => "test.jpg"


### PR DESCRIPTION
The `Juicebox.Stream.Server` and `Juicebox.Stream.Supervisor` modules
have been introduced.

The Server API is as follows:

_.add(stream_id, video)_
Plays the video if one is not already playing, otherwise adds it to the
queue.

_.skip(stream_id)_
Skips the currently playing video

_.remaining_time(stream_id)_
Returns (in ms) the playback time remaining for the current video

_.playing(stream_id)_
Returns the currently playing video (%Juicebox.Youtube.Video{})

Videos will continue to automatically play until the queue is empty.
Adding additional videos will auto-restart playback.

TODO:
- Connect Stream to Phoenix app
- Support ordered stream (by upvotes)
