### PR TITLE
feat(Stream): add `history/1` function

### DIFF
--- a/lib/juicebox/stream/control.ex
+++ b/lib/juicebox/stream/control.ex
@@ -1,0 +1,68 @@
+defmodule Juicebox.Stream.Control do
+  def start(%{playing: nil} = state) do
+    play_next(state)
+  end
+  def start(state), do: state
+
+  def play_next(state) do
+    stop_track(state)
+    |> next_track
+    |> start_timer
+  end
+
+
+  def stop_track(%{playing: nil} = state), do: state
+
+  def stop_track(%{history: history, playing: track} = state) do
+    %{state | playing: nil,
+              history: [track | history]}
+  end
+
+
+  def next_track(%{queue: []} = state) do
+    %{state | playing: nil}
+  end
+
+  def next_track(%{queue: [track | queue]} = state) do
+    %{state | queue: queue, playing: track}
+  end
+
+  def start_timer(state) do
+    clear_timer(state)
+    create_timer(state)
+  end
+
+
+  def create_timer(%{playing: nil} = state) do
+    %{state | timer: nil}
+  end
+
+  def create_timer(%{playing: track} = state) do
+    timer = Process.send_after(self(), :next, track.video.duration)
+    %{state | timer: timer}
+  end
+
+
+  def clear_timer(%{timer: nil}), do: nil
+
+  def clear_timer(%{timer: timer}) do
+    Process.cancel_timer(timer)
+  end
+
+  def add_track(%{queue: queue} = state, track) do
+    new_queue = queue ++ [track]
+    %{state | queue: new_queue}
+  end
+
+  def vote(%{queue: queue} = state, track_id) do
+    track_index = Enum.find_index(queue, fn(x) -> x.track_id == track_id end)
+
+    track = Enum.at(queue, track_index)
+            |> Map.update!(:votes, &(&1 + 1))
+
+    new_queue = List.update_at(queue, track_index, fn(_) -> track end)
+                |> Enum.sort(&(&1.votes > &2.votes))
+
+    %{state | queue: new_queue}
+  end
+end

--- a/lib/juicebox/stream/control.ex
+++ b/lib/juicebox/stream/control.ex
@@ -65,4 +65,10 @@ defmodule Juicebox.Stream.Control do
 
     %{state | queue: new_queue}
   end
+
+  def remaining_time(%{timer: nil}), do: {:error, "Not playing"}
+
+  def remaining_time(%{timer: timer}) do
+    {:ok, Process.read_timer(timer)}
+  end
 end

--- a/lib/juicebox/stream/server.ex
+++ b/lib/juicebox/stream/server.ex
@@ -78,7 +78,7 @@ defmodule Juicebox.Stream.Server do
   end
 
   def handle_call(:remaining_time, _from, state) do
-    {:reply, {:ok, Process.read_timer(state.timer)}, state}
+    {:reply, Control.remaining_time(state), state}
   end
 
   def handle_call(:playing, _from, state) do

--- a/test/juicebox/stream/control_test.exs
+++ b/test/juicebox/stream/control_test.exs
@@ -1,0 +1,80 @@
+defmodule Juicebox.Stream.ControlTests do
+  use ExUnit.Case, async: true
+  alias Juicebox.Stream.Control, as: Control
+
+  setup do
+    [
+      state: %{
+        playing: nil,
+        history: [],
+        queue: [],
+        timer: nil
+      },
+      videos: {
+        %{ track_id: 1, votes: 0 },
+        %{ track_id: 2, votes: 0 },
+        %{ track_id: 3, votes: 0 }
+      }
+    ]
+  end
+
+  describe ".stop_tack" do
+    test "stops playing and adds currently playing tack to history", ctx do
+      {v1, _, _} = ctx.videos
+
+      state = Control.stop_track(%{playing: v1, history: []})
+
+      assert state.playing == nil
+      assert state.history == [v1]
+    end
+  end
+
+  describe ".next_track" do
+    test "removes an item from the queue and starts playing it", ctx do
+      {v1, v2, _} = ctx.videos
+
+      state = Control.next_track(%{playing: nil, queue: [v1, v2]})
+
+      assert state.playing == v1
+      assert state.queue == [v2]
+    end
+  end
+
+  describe ".add_track" do
+    test "adds a track to the queue", ctx do
+      {v1, v2, v3} = ctx.videos
+
+      state = Control.add_track(%{queue: []}, v1)
+              |> Control.add_track(v2)
+              |> Control.add_track(v3)
+
+      assert state.queue == [v1, v2, v3]
+    end
+  end
+
+  describe ".vote" do
+    test "increments the vote count on a given track", ctx do
+      {v1, v2, _} = ctx.videos
+
+      state = Control.vote(%{queue: [v1, v2]}, v1.track_id)
+      %{queue: [video_1, video_2]} = state
+
+      assert video_1.votes == 1
+      assert video_2.votes == 0
+    end
+
+    test "sorts the queue by the number of votes", ctx do
+      {v1, v2, v3} = ctx.videos
+
+      state = %{queue: [v1, v2, v3]}
+              |> Control.vote(v2.track_id)
+              |> Control.vote(v2.track_id)
+              |> Control.vote(v3.track_id)
+      %{queue: [first, second, third]} = state
+
+      assert first.track_id == 2
+      assert second.track_id == 3
+      assert third.track_id == 1
+    end
+  end
+end

--- a/test/juicebox/stream/server_test.exs
+++ b/test/juicebox/stream/server_test.exs
@@ -84,6 +84,10 @@ defmodule Juicebox.Stream.ServerTests do
       {:ok, time} = Stream.remaining_time(@stream)
       assert time <= 10
     end
+
+    test "returns an error if nothing is playing" do
+      assert {:error, _} = Stream.remaining_time(@stream)
+    end
   end
 
   describe ".queue" do

--- a/test/juicebox/stream/server_test.exs
+++ b/test/juicebox/stream/server_test.exs
@@ -9,7 +9,7 @@ defmodule Juicebox.Stream.ServerTests do
   defp create_track(track_id, attrs \\ %{}) do
     %Track{
       track_id: track_id,
-      video: Map.merge(%Video{title: "Video", duration: 100}, attrs)
+      video: Map.merge(%Video{title: "Video", duration: 30}, attrs)
     }
   end
 
@@ -18,9 +18,9 @@ defmodule Juicebox.Stream.ServerTests do
 
     [
       track: create_track(0),
-      track_1: create_track(1, %{title: "Video 1", duration: 100}),
-      track_2: create_track(2, %{title: "Video 2", duration: 100}),
-      track_3: create_track(3, %{title: "Video 3", duration: 100}),
+      track_1: create_track(1, %{title: "Video 1", duration: 30}),
+      track_2: create_track(2, %{title: "Video 2", duration: 30}),
+      track_3: create_track(3, %{title: "Video 3", duration: 30}),
       server: server
     ]
   end
@@ -78,11 +78,11 @@ defmodule Juicebox.Stream.ServerTests do
 
       :timer.sleep(10)
       {:ok, time} = Stream.remaining_time(@stream)
-      assert time <= 90
+      assert time <= 20
 
       :timer.sleep(10)
       {:ok, time} = Stream.remaining_time(@stream)
-      assert time <= 80
+      assert time <= 10
     end
   end
 
@@ -143,6 +143,22 @@ defmodule Juicebox.Stream.ServerTests do
     end
   end
 
+  describe ".history" do
+    test "returns all previously played tracks", ctx do
+      Stream.add(@stream, ctx.track)
+      Stream.add(@stream, ctx.track_1)
+      Stream.add(@stream, ctx.track_2)
+
+      assert Stream.history(@stream) == {:ok, []}
+      Stream.skip(@stream)
+      assert Stream.history(@stream) == {:ok, [ctx.track]}
+      :timer.sleep(35)
+      assert Stream.history(@stream) == {:ok, [ctx.track_1, ctx.track]}
+      Stream.skip(@stream)
+      assert Stream.history(@stream) == {:ok, [ctx.track_2, ctx.track_1, ctx.track]}
+    end
+  end
+
   describe "auto-play" do
     test "automatically plays tracks until the queue is empty", ctx do
       Stream.add(@stream, ctx.track)
@@ -151,13 +167,13 @@ defmodule Juicebox.Stream.ServerTests do
 
       assert Stream.playing(@stream) == {:ok, ctx.track}
 
-      :timer.sleep(105)
+      :timer.sleep(35)
       assert Stream.playing(@stream) == {:ok, ctx.track_1}
 
-      :timer.sleep(105)
+      :timer.sleep(35)
       assert Stream.playing(@stream) == {:ok, ctx.track_2}
 
-      :timer.sleep(105)
+      :timer.sleep(35)
       assert Stream.playing(@stream) == {:ok, nil}
     end
 
@@ -165,13 +181,13 @@ defmodule Juicebox.Stream.ServerTests do
       Stream.add(@stream, ctx.track)
       assert Stream.playing(@stream) == {:ok, ctx.track}
 
-      :timer.sleep(105)
+      :timer.sleep(35)
       assert Stream.playing(@stream) == {:ok, nil}
 
       Stream.add(@stream, ctx.track_1)
       assert Stream.playing(@stream) == {:ok, ctx.track_1}
 
-      :timer.sleep(105)
+      :timer.sleep(35)
       assert Stream.playing(@stream) == {:ok, nil}
     end
 
@@ -186,13 +202,13 @@ defmodule Juicebox.Stream.ServerTests do
       Stream.vote(@stream, 2)
       Stream.vote(@stream, 1)
 
-      :timer.sleep(105)
+      :timer.sleep(35)
       assert Stream.playing(@stream) == {:ok, %{ctx.track_2 | votes: 2}}
 
-      :timer.sleep(105)
+      :timer.sleep(35)
       assert Stream.playing(@stream) == {:ok, %{ctx.track_1 | votes: 1}}
 
-      :timer.sleep(105)
+      :timer.sleep(35)
       assert Stream.playing(@stream) == {:ok, nil}
     end
   end


### PR DESCRIPTION
`Stream.history(stream_id)` now returns a list of all of the previously
played tracks. The `play_next/1` function was refactored heavily to
support this new feature.
