### PR TITLE
refactor(Stream): correct function ordering

### DIFF
--- a/lib/juicebox/stream/server.ex
+++ b/lib/juicebox/stream/server.ex
@@ -97,12 +97,12 @@ defmodule Juicebox.Stream.Server do
 
   def handle_call(:get_queue, _from, %{queue: queue} = state), do: {:reply, {:ok, queue}, state}
 
-  def handle_cast({:vote, track_id}, state) do
-    {:noreply, Control.vote(state, track_id)}
-  end
-
   def handle_call(:history, _from, %{history: history} = state) do
     {:reply, {:ok, history}, state}
+  end
+
+  def handle_cast({:vote, track_id}, state) do
+    {:noreply, Control.vote(state, track_id)}
   end
 
   def handle_info(:next, state) do


### PR DESCRIPTION
Two functions have been swapped over to prevent the following warning:

```
warning: clauses for the same def should be grouped together, def
handle_call/3 was previously defined (lib/juicebox/stream/server.ex:75)
  lib/juicebox/stream/server.ex:104
```
