### PR TITLE
feat(Stream): get streams by name

### DIFF
--- a/lib/juicebox/stream/server.ex
+++ b/lib/juicebox/stream/server.ex
@@ -7,11 +7,11 @@ defmodule Juicebox.Stream.Server do
   alias Juicebox.Stream.Control
 
   def start_link(stream_id) do
-    GenServer.start_link(__MODULE__, %{}, name: via_tuple(stream_id))
+    GenServer.start_link(__MODULE__, stream_id, name: via_tuple(stream_id))
   end
 
-  def init(_) do
-    {:ok, %{playing: nil, timer: nil, queue: [], history: []}}
+  def init(stream_id) do
+    {:ok, %{playing: nil, timer: nil, queue: [], history: [], id: stream_id}}
   end
 
   @doc """
@@ -70,6 +70,16 @@ defmodule Juicebox.Stream.Server do
     GenServer.call(via_tuple(stream_id), :history)
   end
 
+  @doc """
+  Returns the stream id
+  """
+  def id(pid) when is_pid(pid) do
+    GenServer.call(pid, :id)
+  end
+
+  def id(_), do: {:error, "Must be called with a pid"}
+
+
   defp start(stream_id) do
     GenServer.call(via_tuple(stream_id), :start)
   end
@@ -103,6 +113,10 @@ defmodule Juicebox.Stream.Server do
 
   def handle_call(:history, _from, %{history: history} = state) do
     {:reply, {:ok, history}, state}
+  end
+
+  def handle_call(:id, _from, %{id: id} = state) do
+    {:reply, {:ok, id}, state}
   end
 
   def handle_cast({:vote, track_id}, state) do

--- a/lib/juicebox/stream/supervisor.ex
+++ b/lib/juicebox/stream/supervisor.ex
@@ -1,5 +1,6 @@
 defmodule Juicebox.Stream.Supervisor do
   use Supervisor
+  alias Juicebox.Stream.Server, as: Stream
 
   def start_link do
     Supervisor.start_link(__MODULE__, [], name: :stream_supervisor)
@@ -12,11 +13,18 @@ defmodule Juicebox.Stream.Supervisor do
 
   def streams do
     Supervisor.which_children(:stream_supervisor)
+    |> Enum.map(&stream_id_from_child(&1))
+  end
+
+  defp stream_id_from_child({_, pid, _, _}) do
+    case Stream.id(pid) do
+      {:ok, id} -> id
+    end
   end
 
   def init(_) do
     children = [
-      worker(Juicebox.Stream.Server, [])
+      worker(Stream, [])
     ]
 
     supervise(children, strategy: :simple_one_for_one)

--- a/test/juicebox/stream/server_test.exs
+++ b/test/juicebox/stream/server_test.exs
@@ -217,4 +217,17 @@ defmodule Juicebox.Stream.ServerTests do
     end
   end
 
+  describe ".id" do
+    test "with a pid it returns the id of the stream", ctx do
+      {:ok, stream_id} = Stream.id(ctx.server)
+      assert stream_id == @stream
+    end
+
+    test "with a string it returns an error" do
+      {status, _} = Stream.id("some_id")
+
+      assert status == :error
+    end
+  end
+
 end

--- a/test/juicebox/stream/supervisor_test.exs
+++ b/test/juicebox/stream/supervisor_test.exs
@@ -4,8 +4,8 @@ defmodule Juicebox.Stream.SupervisorTests do
 
   setup do
     [
-      stream_1_id: 'stream1',
-      stream_2_id: 'stream2'
+      stream_1_id: "stream1",
+      stream_2_id: "stream2"
     ]
   end
 
@@ -13,7 +13,8 @@ defmodule Juicebox.Stream.SupervisorTests do
     test "returns the default stream, plus any others being added", ctx do
       {:ok, _} = Supervisor.start_stream(ctx.stream_1_id)
       {:ok, _} = Supervisor.start_stream(ctx.stream_2_id)
-      assert length(Supervisor.streams) == 3
+
+      assert Supervisor.streams |> Enum.sort == ["main", "stream1", "stream2"]
     end
   end
 end


### PR DESCRIPTION
`Juicebox.Stream.Supervisor.streams/0` now returns a list of stream ids.

The `Juicebox.Stream.Supervisor.id/1` function was added to support
this. When given a pid `Juicebox.Stream.Supervisor.id/1` returns the
stream's ID.
