### PR TITLE
refactor(Stream): abstract PubSub call

### DIFF
--- a/apps/juicebox_stream/config/dev.exs
+++ b/apps/juicebox_stream/config/dev.exs
@@ -13,6 +13,7 @@ config :juicebox_stream, JuiceboxStream.Repo,
   pool_size: 10
 
 config :juicebox_stream, :youtube_api, JuiceboxStream.Youtube.API
+config :juicebox_stream, :silence_time, 3000
 
 config :juicebox_stream, JuiceboxStream.Youtube,
   api_key: System.get_env("YOUTUBE_API_KEY"),

--- a/apps/juicebox_stream/lib/juicebox_stream/stream/broadcast.ex
+++ b/apps/juicebox_stream/lib/juicebox_stream/stream/broadcast.ex
@@ -1,0 +1,7 @@
+defmodule JuiceboxStream.Stream.Broadcast do
+  def broadcast(stream_id, action, payload, pubsub \\ &Phoenix.PubSub.broadcast/3) do
+    pubsub.(JuiceboxStream.PubSub,
+      "juicebox:stream:server:" <> stream_id,
+      Map.put(payload, :type, action))
+  end
+end

--- a/apps/juicebox_stream/lib/juicebox_stream/stream/server.ex
+++ b/apps/juicebox_stream/lib/juicebox_stream/stream/server.ex
@@ -3,7 +3,7 @@ defmodule JuiceboxStream.Stream.Server do
   Provides playlist-like behaviour for a queue of tracks
   """
   use GenServer
-  alias Phoenix.PubSub
+  import JuiceboxStream.Stream.Broadcast
   alias JuiceboxStream.Stream.Control
 
   def start_link(stream_id) do
@@ -29,7 +29,7 @@ defmodule JuiceboxStream.Stream.Server do
     {:ok, _} = GenServer.call(via_tuple(stream_id), {:add, track})
 
     {:ok, new_queue} = queue(stream_id)
-    PubSub.broadcast(JuiceboxStream.PubSub, "juicebox:stream:server:" <> stream_id, %{ type: "QUEUE_UPDATED", videos: new_queue } )
+    broadcast(stream_id, "QUEUE_UPDATED", %{ videos: new_queue })
 
     # auto-play if nothing was playing
     start(stream_id)

--- a/apps/juicebox_stream/test/juicebox_stream/stream/broadcast_test.exs
+++ b/apps/juicebox_stream/test/juicebox_stream/stream/broadcast_test.exs
@@ -1,0 +1,20 @@
+defmodule JuiceboxStream.Stream.BroadcastTests do
+  use ExUnit.Case, async: true
+  import JuiceboxStream.Stream.Broadcast
+
+  describe ".broadcast/4" do
+    test "broadcasts a message with the correct arguments" do
+      pubsub = fn pubsub, topic, payload ->
+        send self(), { pubsub, topic, payload }
+      end
+
+      broadcast("test", "ACTION", %{ example: "payload" }, pubsub)
+
+      assert_received {
+        JuiceboxStream.PubSub,
+        "juicebox:stream:server:test",
+        %{ type: "ACTION", example: "payload" }
+      }
+    end
+  end
+end


### PR DESCRIPTION
The call to Phoenix PubSub in `JuiceboxStream.Stream.Server` has been
abstracted into the `JuiceboxStream.Stream.Broadcast.broadcast/4`
function.

`broadcast/4` takes an optional 4th argument to allow us to override the
PubSub implementation for testing purposes.