### PR TITLE
feat(Web): pull host config from environment

### DIFF
--- a/apps/juicebox_web/config/prod.exs
+++ b/apps/juicebox_web/config/prod.exs
@@ -13,7 +13,7 @@ use Mix.Config
 # which you typically run after static files are built.
 config :juicebox_web, JuiceboxWeb.Endpoint,
   http: [port: {:system, "PORT"}],
-  url: [host: "example.com", port: 80],
+  url: [host: System.get_env("HOST"), port: 80],
   cache_static_manifest: "priv/static/manifest.json"
 
 # Do not print debug messages in production


### PR DESCRIPTION
The HOST environment variable can now be used in production to adjust
the value of `Endpoint.config(:url)[:host]`.