### PR TITLE
fix(Reactions): playing on mobile

### DIFF
--- a/apps/juicebox_web/assets/js/reactions/styles.scss
+++ b/apps/juicebox_web/assets/js/reactions/styles.scss
@@ -10,7 +10,10 @@
   }
 
   video {
-    display: none;
+    position: absolute;
+    width: 0;
+    height: 0;
+    visibility: hidden;
   }
 }
 

--- a/apps/juicebox_web/assets/js/reactions/video-frame.js
+++ b/apps/juicebox_web/assets/js/reactions/video-frame.js
@@ -76,6 +76,7 @@ class VideoFrame extends Component {
         <video
           autoPlay
           loop
+          muted
           ref={ (video) => { this.video = video } }
           src={ this.props.src }>
         </video>


### PR DESCRIPTION
For videos to autoplay on mobile (tested in Chrome on Android), they
need to have the `muted` attribute set. Videos also appear to not play
if they are set to `display: none`, for this reason an alternative method
of hiding the video element has been used.